### PR TITLE
feat: itests with sideloaded snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .vscode/
 cos-tool*
 version
+*.logs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ pythonVersion = "3.12"
 pythonPlatform = "All"
 
 [tool.pytest.ini_options]
-asyncio_mode = "auto"
 addopts = "--tb=native --verbose --capture=no --log-cli-level=INFO"
 
 [tool.codespell]

--- a/src/machine_lock.py
+++ b/src/machine_lock.py
@@ -26,6 +26,7 @@ class MachineLock:
 
     def _set(self):
         """Set the lock owner to yourself."""
+        self._lockfile.parent.mkdir(parents=True, exist_ok=True)
         self._lockfile.write_text(self._fingerprint)
 
     def acquire(self) -> bool:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,42 @@
+import logging
+import shlex
+import subprocess
+import os
+from pathlib import Path
+from pytest_jubilant import pack
+from pytest import fixture
+
+logger = logging.getLogger("conftest")
+APP_NAME = "profiler"
+
+
+@fixture(scope="module")
+def charm():
+    """Charm used for integration testing."""
+    if charm := os.getenv("CHARM_PATH"):
+        logger.info("using charm from env")
+        return charm
+    if Path(charm := "./otel-ebpf-profiler_ubuntu@24.04-amd64.charm").exists():
+        logger.info("using existing charm from ./")
+        return charm
+    logger.info("packing from ./")
+    return pack("./")
+
+
+def sideload_snap(tmp_path, unit_name):
+    # FIXME: https://github.com/canonical/otel-ebpf-profiler-operator/issues/3
+    if snap_path := os.getenv("SNAP_PATH"):
+        step = f"juju scp {snap_path} {unit_name}:otel-ebpf-profiler.snap"
+        logger.info(step)
+        subprocess.run(shlex.split(step))
+        return
+
+    cwd = tmp_path / "snap"
+    script = [
+        "git clone https://github.com/canonical/otel-ebpf-profiler-snap --depth 1",
+        "snapcraft pack"
+        f"juju scp ./otel-ebpf-profiler_0.130.0_amd64.snap {unit_name}:otel-ebpf-profiler.snap",
+    ]
+    for step in script:
+        logger.info(step)
+        subprocess.run(shlex.split(step), cwd=cwd)

--- a/tests/integration/test_noop.py
+++ b/tests/integration/test_noop.py
@@ -1,2 +1,0 @@
-def test_foo():
-    pass

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,0 +1,35 @@
+import pytest
+import jubilant
+from jubilant import Juju
+
+from conftest import APP_NAME, sideload_snap
+
+
+@pytest.mark.setup
+def test_deploy(juju: Juju, charm):
+    juju.deploy(charm, APP_NAME, constraints={"virt-type": "virtual-machine"})
+    juju.wait(lambda status: jubilant.all_blocked(status, APP_NAME))
+
+
+def test_sideload_snap(juju: Juju, tmp_path):
+    # FIXME: https://github.com/canonical/otel-ebpf-profiler-operator/issues/3
+    unit_name = list(juju.status().apps[APP_NAME].units.keys())[0]
+
+    sideload_snap(tmp_path, unit_name)
+    # this is basically jhack fire install
+    juju.ssh(
+        unit_name,
+        f"sudo /usr/bin/juju-exec -u {unit_name} "
+        "JUJU_DISPATCH_PATH=hooks/install "
+        f"JUJU_MODEL_NAME={juju.model} "
+        f"JUJU_UNIT_NAME={unit_name} "
+        f"/var/lib/juju/agents/unit-{unit_name.replace('/', '-')}/charm/dispatch",
+    )
+
+    juju.wait(jubilant.all_active)
+
+
+def test_profiler_running(juju: Juju):
+    unit_name = list(juju.status().apps[APP_NAME].units.keys())[0]
+    out = juju.ssh(unit_name, "sudo snap logs otel-ebpf-profiler")
+    assert "Everything is ready. Begin running and processing data." in out

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ setenv =
 passenv =
   PYTHONPATH
   CHARM_PATH
+  SNAP_PATH
   KEEP_MODELS
 
 [testenv:lock]


### PR DESCRIPTION
Adds a smoke integration test using a sideloaded, built-on-the-fly snap.

This is not a long-term solution but a workaround so we can test stuff before we close #3 for real