### PR TITLE
feat: detect bad virt type

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -254,7 +254,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 20
+LIBPATCH = 21
 
 PYDEPS = ["cosl >= 0.0.50", "pydantic"]
 
@@ -472,7 +472,7 @@ else:
             return databag
 
 
-class CosAgentProviderUnitData(DatabagModel):
+class CosAgentProviderUnitData(DatabagModel):  # type: ignore
     """Unit databag model for `cos-agent` relation."""
 
     # The following entries are the same for all units of the same principal.
@@ -499,7 +499,7 @@ class CosAgentProviderUnitData(DatabagModel):
     KEY: ClassVar[str] = "config"
 
 
-class CosAgentPeersUnitData(DatabagModel):
+class CosAgentPeersUnitData(DatabagModel):  # type: ignore
     """Unit databag model for `peers` cos-agent machine charm peer relation."""
 
     # We need the principal unit name and relation metadata to be able to render identifiers
@@ -598,7 +598,7 @@ class Receiver(pydantic.BaseModel):
     )
 
 
-class CosAgentRequirerUnitData(DatabagModel):  # noqa: D101
+class CosAgentRequirerUnitData(DatabagModel):  # type: ignore
     """Application databag model for the COS-agent requirer."""
 
     receivers: List[Receiver] = pydantic.Field(

--- a/src/charm.py
+++ b/src/charm.py
@@ -152,7 +152,7 @@ class OtelEbpfProfilerCharm(ops.CharmBase):
             if err_msg := snap_management.check_status(self._snap_name, self._service_name):
                 e.add_status(ops.BlockedStatus(err_msg))
                 break
-            time.sleep(.1)  # this is usually enough to detect early startup failures
+            time.sleep(0.1)  # this is usually enough to detect early startup failures
 
         # assumption: if this is a testing env, the envvar won't be set
         machine_id = os.getenv("JUJU_MACHINE_ID", "<testing>")

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -10,9 +10,9 @@ import platform
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Dict, Optional, Set, Final
+from typing import Dict, Optional, Set, Final, Union
 
-from charms.operator_libs_linux.v2.snap import JSONAble
+from charms.operator_libs_linux.v2.snap import JSONAble, SnapState, SnapCache, Snap
 
 logger = logging.getLogger(__name__)
 
@@ -189,3 +189,29 @@ def reload(snap_name: str, service_name: str):
     except subprocess.CalledProcessError:
         logger.error("error running: '%s'", cmd)
         raise ConfigReloadError("error reloading config")
+
+
+def check_status(snap_name: str, service_name: str) -> Optional[str]:
+    """Verify the status of the snap/service, return an error message or nothing if everything is OK."""
+    snap = SnapCache()[snap_name]
+
+    if snap.state is SnapState.Absent:
+        return f"{snap_name!r} snap is not installed. Check juju logs for any errors during installation."
+
+    service = snap.services[service_name]
+    if not service["active"]:
+        # common error scenario if the service isn't running: the user deployed to a machine
+        # without the right constraints
+        virt_type = subprocess.getoutput("systemd-detect-virt")
+        if virt_type == "lxc":
+            logger.error(
+                "It looks like you deployed this application to a host without the right capabilities. "
+                "To confirm: run `juju constraints <this-app-name>` and verify that "
+                "`virt-type=virtual-machine` is there. If not, this machine can't be instrumented with eBPF "
+                "and you need to redeploy using the right `--constraints`."
+            )
+            return "Snap error on startup: check host machine capabilities (virt-type). See juju logs for more."
+
+        return f"The otel-ebpf-profiler snap is not running. Check `sudo snap logs {snap_name}` for errors."
+
+    return None

--- a/src/snap_management.py
+++ b/src/snap_management.py
@@ -10,9 +10,9 @@ import platform
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Dict, Optional, Set, Final, Union
+from typing import Dict, Optional, Set, Final
 
-from charms.operator_libs_linux.v2.snap import JSONAble, SnapState, SnapCache, Snap
+from charms.operator_libs_linux.v2.snap import JSONAble, SnapState, SnapCache
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/charm/conftest.py
+++ b/tests/unit/charm/conftest.py
@@ -22,6 +22,7 @@ def snap_mocks():
         patch.object(OtelEbpfProfilerCharm, "snap", MagicMock()) as snapmock,
         patch("charm.snap_management", MagicMock()) as snapmgmmock,
     ):
+        snapmgmmock.check_status.return_value = None
         yield SnapMocks(charm_snap=snapmock, snap_mgmt=snapmgmmock)
 
 

--- a/tests/unit/charm/test_lifecycle.py
+++ b/tests/unit/charm/test_lifecycle.py
@@ -1,5 +1,7 @@
+import json
+
 import ops
-from ops.testing import State, CharmEvents
+from ops.testing import State, CharmEvents, Relation
 import pytest
 
 from charm import OtelEbpfProfilerCharm
@@ -33,6 +35,24 @@ def test_blocked_if_fails_acquire_machine_lock(ctx, event, snap_mocks, mock_lock
         CharmEvents.install(),
     ),
 )
+def test_blocked_if_check_status_fails(ctx, event, snap_mocks, mock_lockfile):
+    # GIVEN check_status returns an error message
+    snap_mocks.snap_mgmt.check_status.return_value = "some-error"
+    # WHEN we receive any event
+    state_out = ctx.run(event, State(leader=False))
+    # THEN the unit sets blocked
+    assert state_out.unit_status == ops.BlockedStatus("some-error")
+
+
+@pytest.mark.parametrize(
+    "event",
+    (
+        CharmEvents.upgrade_charm(),
+        CharmEvents.install(),
+        CharmEvents.update_status(),
+        CharmEvents.install(),
+    ),
+)
 def test_snap_not_installed_if_fails_acquire_machine_lock(ctx, event, snap_mocks, mock_lockfile):
     # GIVEN the machine lock is taken
     mock_lockfile.write_text("someone-else")
@@ -49,7 +69,9 @@ def test_smoke(ctx, event, snap_mocks):
     # WHEN we receive any event
     state_out = ctx.run(event, State(leader=True))
     # THEN the unit sets active
-    assert state_out.unit_status == ops.ActiveStatus("profiling machine <testing>")
+    assert state_out.unit_status == ops.ActiveStatus(
+        "profiling machine <testing>, no profiling ingester/backend connected"
+    )
 
 
 @pytest.mark.parametrize("event", (CharmEvents.upgrade_charm(), CharmEvents.install()))
@@ -62,9 +84,34 @@ def test_install_snap(ctx, event, snap_mocks):
         ops.MaintenanceStatus(f"Installing {OtelEbpfProfilerCharm._snap_name} snap")
         in ctx.unit_status_history
     )
-    assert state_out.unit_status == ops.ActiveStatus("profiling machine <testing>")
+    assert state_out.unit_status == ops.ActiveStatus(
+        "profiling machine <testing>, no profiling ingester/backend connected"
+    )
     assert snap_mocks.snap_mgmt.install_snap.called
     assert snap_mocks.charm_snap.return_value.start.called
+
+
+@pytest.mark.parametrize("event", (CharmEvents.upgrade_charm(), CharmEvents.install()))
+def test_profiling_related_status(ctx, event, snap_mocks):
+    # GIVEN we have a profiling relation
+    # WHEN we receive any event
+    state_out = ctx.run(
+        event,
+        State(
+            leader=True,
+            relations={
+                Relation(
+                    "profiling",
+                    remote_app_data={
+                        "otlp_grpc_endpoint_url": json.dumps("foo.com"),
+                        # "insecure": json.dumps(True),
+                    },
+                )
+            },
+        ),
+    )
+    # THEN the unit will set active status
+    assert state_out.unit_status == ops.ActiveStatus("profiling machine <testing>")
 
 
 @pytest.mark.parametrize("event", (CharmEvents.stop(), CharmEvents.remove()))
@@ -77,7 +124,9 @@ def test_remove_snap(ctx, event, snap_mocks):
         ops.MaintenanceStatus(f"Uninstalling {OtelEbpfProfilerCharm._snap_name} snap")
         in ctx.unit_status_history
     )
-    assert state_out.unit_status == ops.ActiveStatus("profiling machine <testing>")
+    assert state_out.unit_status == ops.ActiveStatus(
+        "profiling machine <testing>, no profiling ingester/backend connected"
+    )
     assert snap_mocks.snap_mgmt.cleanup_config.called
     assert snap_mocks.charm_snap.return_value.ensure.called_with_args(state=snap.SnapState.Absent)
 
@@ -98,4 +147,6 @@ def test_config_reload(ctx, event, snap_mocks, changes):
     else:
         assert not snap_mocks.snap_mgmt.reload.called
 
-    assert state_out.unit_status == ops.ActiveStatus("profiling machine <testing>")
+    assert state_out.unit_status == ops.ActiveStatus(
+        "profiling machine <testing>, no profiling ingester/backend connected"
+    )

--- a/tests/unit/charm/test_lifecycle.py
+++ b/tests/unit/charm/test_lifecycle.py
@@ -104,7 +104,7 @@ def test_profiling_related_status(ctx, event, snap_mocks):
                     "profiling",
                     remote_app_data={
                         "otlp_grpc_endpoint_url": json.dumps("foo.com"),
-                        # "insecure": json.dumps(True),
+                        "insecure": json.dumps(True),
                     },
                 )
             },

--- a/tests/unit/test_snap_mgmt.py
+++ b/tests/unit/test_snap_mgmt.py
@@ -1,9 +1,10 @@
 from collections import namedtuple
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
 import snap_management
+from charms.operator_libs_linux.v2.snap import SnapState
 
 CfgMocks = namedtuple("CfgMocks", "config, hash")
 
@@ -80,3 +81,63 @@ def test_cleanup(mock_paths):
     # THEN the files are gone
     assert not mock_paths.config.exists()
     assert not mock_paths.hash.exists()
+
+
+def test_check_status_snap_absent(caplog):
+    # GIVEN the snap is absent
+    foo_snap = MagicMock()
+    with patch("snap_management.SnapCache", return_value={"foo": foo_snap}):
+        foo_snap.state = SnapState.Absent
+        # WHEN we call check_status
+        status = snap_management.check_status("foo", "bar")
+
+    # THEN check_status returns an error message
+    assert status is not None
+    assert "snap is not installed" in status
+
+
+def test_check_status_service_inactive(caplog):
+    # GIVEN the snap is absent
+    foo_snap = MagicMock()
+    with patch("snap_management.SnapCache", return_value={"foo": foo_snap}):
+        foo_snap.services = {"bar": {"active": False}}
+
+        # WHEN we call check_status
+        status = snap_management.check_status("foo", "bar")
+
+    # THEN check_status returns an error message
+    assert status is not None
+    assert "snap is not running" in status
+
+
+def test_check_status_bad_virt_type(caplog):
+    # GIVEN a lxc virt-type
+    foo_snap = MagicMock()
+    with patch("snap_management.SnapCache", return_value={"foo": foo_snap}):
+        foo_snap.services = {"bar": {"active": False}}
+        with patch("subprocess.getoutput", return_value="lxc"):
+            # WHEN we call check_status
+            with caplog.at_level("ERROR"):
+                caplog.clear()
+                status = snap_management.check_status("foo", "bar")
+                error_msgs = caplog.records
+
+    # THEN check_status returns an error message
+    assert status is not None
+    assert "check host machine capabilities" in status
+    # AND THEN we captured a log message about it too
+    assert any("virt-type=virtual-machine" in emsg.message for emsg in error_msgs)
+
+
+def test_check_status_not_running(caplog):
+    # GIVEN the snap isn't running for any reason
+    foo_snap = MagicMock()
+    with patch("snap_management.SnapCache", return_value={"foo": foo_snap}):
+        foo_snap.services = {"bar": {"active": False}}
+        with patch("subprocess.getoutput", return_value="kvm"):
+            # WHEN we call check_status
+            status = snap_management.check_status("foo", "bar")
+
+    # THEN check_status returns an error message
+    assert status is not None
+    assert "snap is not running" in status

--- a/tests/unit/test_snap_mgmt.py
+++ b/tests/unit/test_snap_mgmt.py
@@ -97,7 +97,7 @@ def test_check_status_snap_absent(caplog):
 
 
 def test_check_status_service_inactive(caplog):
-    # GIVEN the snap is absent
+    # GIVEN the snap service is inactive
     foo_snap = MagicMock()
     with patch("snap_management.SnapCache", return_value={"foo": foo_snap}):
         foo_snap.services = {"bar": {"active": False}}


### PR DESCRIPTION
Fixes: #8 

Flyby:
- added status message if no 'profiling' relation is active, so the user knows we're profiling into the void

For posterity: we discussed various alternatives for detecting the user error:
- parsing the snap logs to find a specific line and set an adequate error message/log
- simply surface the error "snap is not running, 9/10 times it's this issue"

Eventually I found out there's `systemd-detect-virt` in ubuntu which allows us to catch the situation in which the host is a container, which seems to cover the typical error scenario without hardcoding error message text, so I opted for this solution.

To test:
```
juju deploy ./otel-ebpf-profiler_ubuntu@24.04-amd64.charm --constraints="virt-type=virtual-machine" profiler-kvm
juju deploy ./otel-ebpf-profiler_ubuntu@24.04-amd64.charm profiler-lxd
```
Wait until profiler-kvm goes to active ("profiling machine X, no profiling ingester/backend connected") 
Wait until profiler-lcd goes to blocked ("Snap error on startup: check host machine capabilities (virt-type). See juju logs for more.") 