### PR TITLE
chore: add an itest for profiling over TLS

### DIFF
--- a/tests/integration/profiling-tls.feature
+++ b/tests/integration/profiling-tls.feature
@@ -1,0 +1,10 @@
+Feature: profiling-tls
+
+  Scenario: eBPF profiler is able to send system-wide profiles to a profiling backend over TLS
+    Given an ebpf profiler charm is deployed on a juju virtual machine
+    * an otel collector charm is deployed on the same machine
+    * a certificates provider charm is deployed
+    * the certificates provider charm is integrated with the collector to enable TLS
+    * the certificates provider charm is integrated with the profiler to provide the CA
+    When the profiler is integrated with the collector over profiling
+    Then system-wide profiles are successfully pushed to the collector over TLS

--- a/tests/integration/profiling.feature
+++ b/tests/integration/profiling.feature
@@ -1,0 +1,7 @@
+Feature: profiling
+
+  Scenario: eBPF profiler is able to send system-wide profiles to a profiling backend
+    Given an ebpf profiler charm is deployed on a juju virtual machine
+    * an otel collector charm is deployed on the same machine
+    When the profiler is integrated with the collector over profiling
+    Then system-wide profiles are successfully pushed to the collector

--- a/tests/integration/self-monitoring.feature
+++ b/tests/integration/self-monitoring.feature
@@ -1,4 +1,4 @@
-Feature: Self-monitoring integration with OTel Collector
+Feature: self-monitoring
 
   Scenario: eBPF profiler self-monitoring data is scraped and aggregated
     Given an otel-ebpf-profiler charm is deployed

--- a/tests/integration/test_profiling_integration.py
+++ b/tests/integration/test_profiling_integration.py
@@ -1,6 +1,6 @@
 import pytest
 import jubilant
-from jubilant import Juju, all_active
+from jubilant import Juju, all_blocked
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from conftest import (
@@ -41,7 +41,7 @@ def test_deploy_otel_collector(juju: Juju):
     # to get otelcol deployed and assigned to a machine
     juju.integrate(f"{APP_NAME}:juju-info", OTEL_COLLECTOR_APP_NAME)
     juju.wait(
-        lambda status: all_active(status, OTEL_COLLECTOR_APP_NAME),
+        lambda status: all_blocked(status, OTEL_COLLECTOR_APP_NAME),
         timeout=10 * 60,
         delay=10,
         successes=3,

--- a/tests/integration/test_profiling_integration_tls.py
+++ b/tests/integration/test_profiling_integration_tls.py
@@ -1,6 +1,6 @@
 import pytest
 import jubilant
-from jubilant import Juju, all_active
+from jubilant import Juju, all_active, any_error
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from conftest import (
@@ -13,6 +13,7 @@ from conftest import (
 from assertions import assert_pattern_in_snap_logs
 from pytest_bdd import given, when, then
 
+SSC_APP_NAME = "ssc"
 # patch the update-status-hook-interval because if the otel collector charm handles an event, it will regenerate its config and overwrite the config patch
 pytestmark = pytest.mark.usefixtures("patch_update_status_interval")
 
@@ -26,7 +27,6 @@ def test_deploy(juju: Juju, charm):
 
 def test_profiler_running(juju: Juju):
     unit_name = list(juju.status().apps[APP_NAME].units.keys())[0]
-
     out = juju.ssh(
         unit_name,
         'sudo snap services otel-ebpf-profiler | awk \'$2=="enabled" && $3=="active"\'',
@@ -48,10 +48,44 @@ def test_deploy_otel_collector(juju: Juju):
     )
 
 
+@pytest.mark.setup
+@given("a certificates provider charm is deployed")
+def test_deploy_ssc(juju: Juju):
+    juju.deploy("self-signed-certificates", SSC_APP_NAME)
+    juju.wait(
+        lambda status: all_active(status, SSC_APP_NAME),
+        timeout=10 * 60,
+    )
+
+
+@pytest.mark.setup
+@given("the certificates provider charm is integrated with the collector to enable TLS")
+def test_integrate_ssc_collector(juju: Juju):
+    juju.integrate(f"{OTEL_COLLECTOR_APP_NAME}:receive-server-cert", SSC_APP_NAME)
+    juju.wait(
+        lambda status: all_active(status, OTEL_COLLECTOR_APP_NAME, SSC_APP_NAME),
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+
+
+@pytest.mark.setup
+@given("the certificates provider charm is integrated with the profiler to provide the CA")
+def test_integrate_ssc_profiler(juju: Juju):
+    juju.integrate(f"{APP_NAME}:receive-ca-cert", SSC_APP_NAME)
+    juju.wait(
+        lambda status: all_active(status, APP_NAME, SSC_APP_NAME),
+        timeout=10 * 60,
+        error=lambda status: any_error(status, APP_NAME),
+        delay=10,
+        successes=3,
+    )
+
+
 @when("the profiler is integrated with the collector over profiling")
 def test_integrate_profiling(juju: Juju):
     juju.integrate(f"{APP_NAME}:profiling", OTEL_COLLECTOR_APP_NAME)
-
     juju.wait(
         lambda status: jubilant.all_blocked(status, OTEL_COLLECTOR_APP_NAME),
         timeout=10 * 60,
@@ -71,7 +105,7 @@ def test_integrate_profiling(juju: Juju):
 
 
 @retry(stop=stop_after_attempt(10), wait=wait_fixed(10))
-@then("system-wide profiles are successfully pushed to the collector")
+@then("system-wide profiles are successfully pushed to the collector over TLS")
 def test_profiles_are_pushed(juju: Juju):
     grep_filters = [
         '"otelcol.component.kind": "exporter"',

--- a/tests/integration/test_profiling_integration_tls.py
+++ b/tests/integration/test_profiling_integration_tls.py
@@ -1,6 +1,6 @@
 import pytest
 import jubilant
-from jubilant import Juju, all_active, any_error
+from jubilant import Juju, all_active, any_error, all_blocked
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from conftest import (
@@ -41,7 +41,7 @@ def test_deploy_otel_collector(juju: Juju):
     # to get otelcol deployed and assigned to a machine
     juju.integrate(f"{APP_NAME}:juju-info", OTEL_COLLECTOR_APP_NAME)
     juju.wait(
-        lambda status: all_active(status, OTEL_COLLECTOR_APP_NAME),
+        lambda status: all_blocked(status, OTEL_COLLECTOR_APP_NAME),
         timeout=10 * 60,
         delay=10,
         successes=3,
@@ -63,7 +63,13 @@ def test_deploy_ssc(juju: Juju):
 def test_integrate_ssc_collector(juju: Juju):
     juju.integrate(f"{OTEL_COLLECTOR_APP_NAME}:receive-server-cert", SSC_APP_NAME)
     juju.wait(
-        lambda status: all_active(status, OTEL_COLLECTOR_APP_NAME, SSC_APP_NAME),
+        lambda status: all_blocked(status, OTEL_COLLECTOR_APP_NAME),
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+    juju.wait(
+        lambda status: all_active(status, SSC_APP_NAME),
         timeout=10 * 60,
         delay=10,
         successes=3,


### PR DESCRIPTION
Fixes #17 

## Drive-bys
- feature files for profiling and profiling-tls
- fix the feature ID for self-monitoring feature file