### PR TITLE
test: migrate to pytest-jubilant 2.0

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@v2
     with:
       promotion: ${{ github.event.inputs.promotion }}
     secrets: inherit

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,6 +6,13 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for all workflows
+  security-events: write
+  # Only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   pull-request:
     name: PR

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,14 +9,14 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
     secrets: inherit
     with:
       provider: machine
 
   terraform-deploy-tests:
     name: Run terraform deployment tests
-    uses: canonical/observability/.github/workflows/run-tox-environment.yaml@v1
+    uses: canonical/observability/.github/workflows/run-tox-environment.yaml@v2
     with:
       tox-env-name: terraform
       run-on: "self-hosted-linux-amd64-noble-medium"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -21,13 +21,14 @@ jobs:
     with:
       provider: machine
 
-  terraform-deploy-tests:
-    name: Run terraform deployment tests
-    uses: canonical/observability/.github/workflows/run-tox-environment.yaml@v2
-    with:
-      tox-env-name: terraform
-      run-on: "self-hosted-linux-amd64-noble-medium"
-      prepare-host-env: true
-      provider: machine
-      extra-snaps: terraform
-    secrets: inherit
+  # Comment it out for now as it's always failing
+  # terraform-deploy-tests:
+  #   name: Run terraform deployment tests
+  #   uses: canonical/observability/.github/workflows/run-tox-environment.yaml@v2
+  #   with:
+  #     tox-env-name: terraform
+  #     run-on: "self-hosted-linux-amd64-noble-medium"
+  #     prepare-host-env: true
+  #     provider: machine
+  #     extra-snaps: terraform
+  #   secrets: inherit

--- a/.github/workflows/quality-gates.yaml
+++ b/.github/workflows/quality-gates.yaml
@@ -12,5 +12,5 @@ on:
 jobs:
   quality-gates:
     name: Run quality gates
-    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,13 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for all workflows
+  security-events: write
+  # Only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,8 @@ permissions:
   security-events: write
   # Only required for workflows in private repositories
   actions: read
-  contents: read
+  # Write permission needed for the reusable workflow to push git tags
+  contents: write
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    uses: canonical/observability/.github/workflows/charm-release.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v2
     secrets: inherit
     with:
       provider: machine

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -8,5 +8,5 @@ on:
 jobs:
     tics:
         name: TiCs
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v2
         secrets: inherit

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,6 +9,6 @@ on:
 jobs:
   update-lib:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
     secrets: inherit
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ version
 *.hcl
 .terraform
 *.tfstate*
+# Terraform
+**/.terraform.lock.hcl

--- a/.tfdocs.yaml
+++ b/.tfdocs.yaml
@@ -1,0 +1,41 @@
+# https://terraform-docs.io/user-guide/configuration/
+
+formatter: markdown table
+
+sections:
+  show:
+    - requirements
+    - modules
+    - providers
+    - inputs
+    - outputs
+
+# This allows us to customize the injected docs
+content: ""
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  # anchor: true
+  color: true
+  default: true
+  description: true
+  # escape: true
+  # hide-empty: false
+  # html: true
+  # indent: 2
+  lockfile: false
+  # read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,7 +9,33 @@ type: charm
 
 summary: A whole-system, cross-language profiler for Linux via eBPF.
 description: |
-  A whole-system, cross-language profiler for Linux via eBPF.  
+  OTel eBPF Profiler is a Juju charm that deploys and manages the OpenTelemetry eBPF
+  Profiler on Linux machine models. It is an optional complement to the Canonical
+  Observability Stack (COS):
+  https://documentation.ubuntu.com/observability
+
+  The OpenTelemetry eBPF Profiler is a whole-system, cross-language continuous profiler
+  for Linux. It uses eBPF to gather CPU profiling data from all running processes
+  without requiring any instrumentation or language-specific agents, supporting Go,
+  Rust, C/C++, Java, PHP, Python, Ruby, Node.js, and more.
+
+  This is a machine charm: it deploys the otel-ebpf-profiler snap as a classic snap on
+  bare-metal or virtual machines, and forwards the collected profiles to a Pyroscope
+  backend or an OpenTelemetry Collector.
+
+  Key features:
+
+  - Whole-system profiling via eBPF: captures CPU profiles across all processes on the
+    host with no code changes or per-language instrumentation required.
+  - Cross-language support: profiles Go, Rust, Zig, C/C++, Java (Hotspot JVM), Python,
+    Ruby, PHP, Node.js, Perl, Erlang, .NET, and other runtimes running on the same host.
+  - Forwards profiling data to a Pyroscope backend via the profiling relation, or to an
+    OpenTelemetry Collector.
+  - Self-monitoring: exposes Prometheus metrics and forwards logs via the cos-agent
+    relation to Grafana Agent or an OpenTelemetry Collector.
+  - TLS support: accepts CA certificates via the receive-ca-cert relation to push
+    profiles securely to TLS-enabled backends.
+  - Only one instance per machine is allowed, enforced at charm level.
 
 links:
   documentation: https://discourse.charmhub.io/t/18805

--- a/charms.just
+++ b/charms.just
@@ -1,0 +1,348 @@
+# Centralized justfile for the Canonical Observability charms
+set shell := ["bash", "-uc"]
+
+charm_name := `echo ${PWD##*/} | sed 's/-operator$//'`  # Get the charm name from the folder name
+
+export UV_FROZEN := "true"  # Prevent `uv run` from updating the lockfile
+export PYTHONPATH := ".:./lib:./src"
+
+
+[private]
+@default:
+    just --list
+
+# Print the charm name
+[group("info")]
+@name:
+  echo "{{charm_name}}"
+
+# List all track branches in chronological order (oldest first)
+[group("info")]
+tracks:
+    #!/usr/bin/env python3
+    import subprocess
+
+    def git(*args):
+        r = subprocess.run(["git", *args], capture_output=True, text=True)
+        return r.stdout.strip() if r.returncode == 0 else None
+
+    branches = git("branch", "-r", "--list", "origin/track/*")
+    if not branches:
+        exit(0)
+
+    dated = []
+    for line in branches.splitlines():
+        branch = line.strip().removeprefix("origin/")
+        merge_base = git("merge-base", f"origin/{branch}", "origin/main")
+        if not merge_base:
+            continue
+        first = git("rev-list", "--ancestry-path", f"{merge_base}..origin/{branch}", "--reverse")
+        commit = first.splitlines()[0] if first else merge_base
+        date = git("log", "-1", "--format=%at", commit)
+        dated.append((int(date), branch))
+
+    for _, branch in sorted(dated):
+        print(branch)
+
+# Get the previous track branch relative to the current branch
+[group("info")]
+previous-track:
+    #!/usr/bin/env python3
+    import subprocess
+    import sys
+
+    def git(*args):
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()
+
+    def just(*args):
+        r = subprocess.run(["just", *args], capture_output=True, text=True)
+        if r.returncode != 0:
+            sys.exit(r.returncode)
+        return r.stdout.strip()
+
+    current = git("rev-parse", "--abbrev-ref", "HEAD")
+    tracks = just("tracks").splitlines() if just("tracks") else []
+
+    if not tracks:
+        print("No track branches found", file=sys.stderr)
+        sys.exit(1)
+
+    if current == "main":
+        print(tracks[-1])
+    elif current in tracks:
+        idx = tracks.index(current)
+        if idx > 0:
+            print(tracks[idx - 1])
+    else:
+        print(f"Cannot determine previous track from branch '{current}'", file=sys.stderr)
+        print("Specify ref explicitly: just changelog <ref>", file=sys.stderr)
+        sys.exit(1)
+
+# Update uv.lock dependencies
+[group("maintenance")]
+lock:
+    unset UV_FROZEN; uv lock --upgrade --no-cache
+
+# Scan for security vulnerabilities
+[group("maintenance")]
+scan:
+    @echo "Scanning for security vulnerabilities..."
+    uvx uv-secure
+
+# Fetch centralized files from canonical/observability
+[group("maintenance")]
+refresh:
+    #!/usr/bin/env bash
+    which -s gh || { echo "gh not found"; exit 1; }
+    refresh_folder="blueprints/charms"
+    api_path="repos/canonical/observability/contents/$refresh_folder"
+    for file in charms.just .tfdocs.yaml; do
+      echo "Fetching latest '$file' from canonical/observability ..."
+      gh api "$api_path/$file" --jq '.content' | base64 --decode > "$file"
+      echo "✓ $file updated"
+    done
+
+
+# Format the codebase
+[group("dev")]
+format: sync
+    # Fix generic linting issues
+    uv run ruff check --fix-only
+    # Fix import-related issues (including ordering)
+    uv run ruff check --select=I --fix-only
+    # Format the code
+    uv run ruff format
+
+alias fmt := format
+
+# Lint the codebase
+[group("dev")]
+lint: sync
+    # Lint the code
+    uv run ruff check
+    # Run static checks
+    uv run ty check src
+    # Check for misspellings
+    uv run codespell src
+    # Check for dead code (heuristic, so failures are ignored)
+    uv run vulture src --min-confidence=80 || true
+    # Run actionlint on GitHub Actions workflows
+    test -d .github/workflows && uvx --from=actionlint-py actionlint
+    @echo "✓ Linting passed!"
+
+
+# Run all quality checks: formatting, linting and unit tests
+[group("dev")]
+check: sync format lint unit
+    @echo; echo "✓ All checks passed!"
+
+# Sync the virtual environment (.venv)
+[group("dev")]
+sync:
+    uv sync --all-groups --all-extras
+
+# Sync and activate the virtual environment (.venv)
+[group("dev")]
+venv:
+    @echo "Activating virtual environment..."
+    @uv sync --all-groups --all-extras
+    @. .venv/bin/activate; exec "$SHELL" -i
+
+
+# Run unit tests
+[group("test")]
+unit *args: sync
+    uv run coverage run --source=src -m pytest tests/unit {{ args }}
+
+# Run integration tests
+[group("test")]
+integration *args: sync
+    uv run pytest --exitfirst tests/integration {{ args }}
+
+# Pretty print all feature files
+[group("info")]
+features:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    features_dir="tests/integration/features"
+    if [ ! -d "$features_dir" ]; then
+        echo "No features directory found at $features_dir"
+        exit 1
+    fi
+    # Calculate totals first
+    total_features=$(find "$features_dir" -name "*.feature" -type f | wc -l)
+    total_scenarios=$(grep -rh "^[[:space:]]*Scenario:" "$features_dir" 2>/dev/null | wc -l || echo "0")
+    printf "Total: \033[1m%d features\033[0m with \033[1m%d scenarios\033[0m\n" "$total_features" "$total_scenarios"
+    echo ""
+    for feature_file in "$features_dir"/*.feature; do
+        [ -f "$feature_file" ] || continue
+        filename=$(basename "$feature_file")
+        feature_name="${filename%.feature}"
+        # Extract the Feature: line
+        feature_title=$(grep -m1 "^Feature:" "$feature_file" | sed 's/Feature: //')
+        # Extract feature description (lines after Feature: until first Scenario, skipping blank lines)
+        description=$(awk '/^Feature:/{found=1; next} found && /^[[:space:]]*Scenario/{exit} found && /^[[:space:]]*$/{next} found{gsub(/^[[:space:]]+/, ""); print}' "$feature_file" | head -3)
+        # Count scenarios
+        scenario_count=$(grep -c "^[[:space:]]*Scenario:" "$feature_file" || echo "0")
+        echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        printf "\033[1m%s\033[0m (%d scenarios)\n" "$feature_title" "$scenario_count"
+        echo "   $feature_file"
+        echo ""
+        if [ -n "$description" ]; then
+            echo "$description" | while IFS= read -r line; do
+                echo "   $line"
+            done
+            echo ""
+        fi
+        # List scenarios
+        grep "^[[:space:]]*Scenario:" "$feature_file" | sed 's/^[[:space:]]*Scenario:[[:space:]]*//' | while IFS= read -r scenario; do
+            echo "   - $scenario"
+        done
+        echo ""
+    done
+
+
+# Update the Terraform README with auto-generated content
+[group("terraform")]
+terraform-docs:
+    which terraform-docs > /dev/null 2>&1 || { echo "× terraform-docs not found"; exit 1; }
+    terraform-docs --config .tfdocs.yaml .
+    @echo "✓ Terraform docs updated"
+
+# Lint and validate the Terraform module
+[group("terraform")]
+terraform-lint:
+    which terraform > /dev/null 2>&1 || { echo "× terraform not found"; exit 1; }
+    cd terraform && terraform init -backend=false && terraform validate
+    terraform fmt -recursive -check
+    @echo "✓ Terraform lint passed"
+
+
+# Release a .charm file to Charmhub
+[group("release")]
+release charm_file channel:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Upload the charm and get the revision
+    echo "Uploading charm {{ charm_file }}..."
+    upload_output=$(charmcraft upload "{{ charm_file }}" --format=json)
+    charm_revision=$(echo "$upload_output" | jq -r '.revision')
+    echo "✓ Uploaded charm revision: $charm_revision"
+    # Get resources from charmcraft.yaml
+    resource_args=""
+    if [ -f charmcraft.yaml ]; then
+        while IFS= read -r resource_name; do
+            upstream=$(yq -r ".resources.\"$resource_name\".\"upstream-source\" // empty" charmcraft.yaml)
+            if [ -n "$upstream" ]; then
+                echo "Uploading resource '$resource_name' from $upstream..."
+                res_output=$(charmcraft upload-resource "{{ charm_name }}" "$resource_name" --image="docker://$upstream" --format=json)
+                res_revision=$(echo "$res_output" | jq -r '.revision')
+            else
+                echo "Fetching latest revision for resource '$resource_name'..."
+                res_revision=$(charmcraft resource-revisions "{{ charm_name }}" "$resource_name" --format=json | jq -r '.[0].revision')
+            fi
+            echo "✓ Resource '$resource_name' revision: $res_revision"
+            resource_args="$resource_args --resource=$resource_name:$res_revision"
+        done < <(yq -r '.resources | keys | .[]' charmcraft.yaml 2>/dev/null || true)
+    fi
+    # Release the charm
+    echo "Releasing {{ charm_name }} to {{ channel }}..."
+    # shellcheck disable=SC2086
+    charmcraft release "{{ charm_name }}" --revision="$charm_revision" --channel="{{ channel }}" $resource_args
+    echo "✓ Released {{ charm_name }} revision $charm_revision to {{ channel }}"
+
+# Print all commits between two refs (auto-deduces refs when on main or track branches)
+[group("release")]
+[arg("from_ref", help="Branch (or generic ref) to compare from (defaults to previous track)")]
+[arg("to_ref", help="Branch (or generic ref) to compare to (defaults to current branch)")]
+changelog from_ref="" to_ref="":
+    #!/usr/bin/env python3
+    import os
+    import re
+    import subprocess
+    import sys
+
+    def git(*args):
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()
+
+    def just(*args):
+        result = subprocess.run(["just", *args], capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr, end="")
+            sys.exit(result.returncode)
+        return result.stdout.strip()
+
+    # Get repo path from remote URL
+    remote_url = git("remote", "get-url", "origin")
+    match = re.search(r"github\.com[:/]([^/]+/[^/.]+)", remote_url)
+    repo_path = match.group(1) if match else ""
+
+    # Resolve from_ref (auto-deduce if empty)
+    from_ref = "{{ from_ref }}"
+    if not from_ref:
+        from_ref = just("previous-track")
+        if not from_ref:
+            print("No previous track to compare against", file=sys.stderr)
+            sys.exit(1)
+    try:
+        git("rev-parse", "--verify", from_ref)
+    except subprocess.CalledProcessError:
+        from_ref = f"origin/{from_ref}"
+
+    # Resolve to_ref (default to current branch)
+    to_ref = "{{ to_ref }}" or git("rev-parse", "--abbrev-ref", "HEAD")
+    try:
+        git("rev-parse", "--verify", to_ref)
+    except subprocess.CalledProcessError:
+        to_ref = f"origin/{to_ref}"
+
+    # Get merge-base and commits
+    base = git("merge-base", to_ref, from_ref)
+    log_output = git("log", f"--format=%H\t%s", f"{base}..{to_ref}", "--", os.getcwd())
+
+    # Categorize commits
+    categories = {"breaking": [], "features": [], "fixes": [], "others": []}
+
+    for line in log_output.splitlines():
+        if not line:
+            continue
+        hash, msg = line.split("\t", 1)
+
+        # Skip changelog update commits
+        if msg.startswith("chore(changelog)"):
+            continue
+        short_hash = hash[:7]
+
+        # Format line with links
+        pr_match = re.search(r"\(#(\d+)\)", msg)
+        if pr_match and repo_path:
+            pr_num = pr_match.group(1)
+            formatted = f"- {msg.replace(f'(#{pr_num})', f'([#{pr_num}](https://github.com/{repo_path}/pull/{pr_num}))')}"
+        elif repo_path:
+            formatted = f"- {msg} ([{short_hash}](https://github.com/{repo_path}/commit/{hash}))"
+        else:
+            formatted = f"- {msg} ({short_hash})"
+
+        # Categorize
+        if re.match(r"^[a-z]+(\(.+\))?!:", msg):
+            categories["breaking"].append(formatted)
+        elif re.match(r"^feat(\(.+\))?:", msg):
+            categories["features"].append(formatted)
+        elif re.match(r"^fix(\(.+\))?:", msg):
+            categories["fixes"].append(formatted)
+        else:
+            categories["others"].append(formatted)
+
+    # Print changelog
+    short_base = base[:7]
+    print("# Changelog\n")
+    print(f"Changes on `{to_ref}` since the common ancestor with `{from_ref}` (`{short_base}`).\n")
+    sections = [("Breaking Changes", "breaking"), ("Features", "features"), ("Fixes", "fixes"), ("Others", "others")]
+    for title, key in sections:
+        if categories[key]:
+            print(f"## {title}\n")
+            print("\n".join(categories[key]))
+            print()
+
+
+

--- a/justfile
+++ b/justfile
@@ -1,0 +1,9 @@
+set allow-duplicate-recipes
+set allow-duplicate-variables
+import? 'charms.just'
+
+[private]
+@default:
+  just --list
+  echo ""
+  echo "For help with a specific recipe, run: just --usage <recipe>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dev = [
   "pytest",
   "coverage[toml]",
   # Integration
-  "pytest-jubilant",
+  "pytest-jubilant>=2,<3",
   "ops[testing]",
   "jubilant",
   "tenacity",

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,3 +48,44 @@ The `virt-type` constraint should not be changed or removed, as deploying this c
 
 For example, if you want to deploy `otel-ebpf-profiler` to a machine with a different architecture, you should set `constraints` to `arch=arm64,virt-type=virtual-machine`.
 
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
+
+## Modules
+
+No modules.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"otel-ebpf-profiler"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64 virt-type=virtual-machine"` | no |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_trust"></a> [trust](#input\_trust) | Whether this application is trusted to control the cluster | `bool` | `false` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -55,13 +55,13 @@ For example, if you want to deploy `otel-ebpf-profiler` to a machine with a diff
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 1.0 |
 
 ## Modules
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@ resource "juju_application" "otel_ebpf_profiler" {
   name               = var.app_name
   config             = var.config
   constraints        = var.constraints
-  model              = var.model
+  model_uuid         = var.model_uuid
   storage_directives = var.storage_directives
   trust              = var.trust
   units              = var.units

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,13 +2,15 @@ output "app_name" {
   value = juju_application.otel_ebpf_profiler.name
 }
 
-output "endpoints" {
+output "provides" {
   value = {
-    # Requires
+    cos-agent = "cos-agent",
+  }
+}
+
+output "requires" {
+  value = {
     profiling       = "profiling",
     receive_ca_cert = "receive-ca-cert",
-
-    # Provides
-    cos-agent = "cos-agent",
   }
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = ">= 1.0"
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {
@@ -22,7 +27,7 @@ variable "constraints" {
   default = "arch=amd64 virt-type=virtual-machine"
 }
 
-variable "model" {
+variable "model_uuid" {
   description = "Reference to an existing model resource or data source for the model to deploy to"
   type        = string
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.15.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,7 +2,7 @@ import logging
 import os
 from pathlib import Path
 import platform
-from pytest_jubilant import pack
+import subprocess
 from pytest import fixture
 from jubilant import Juju
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -67,4 +67,32 @@ def charm():
         logger.info(f"using existing charm from {REPO_ROOT}")
         return charm
     logger.info(f"packing from {REPO_ROOT}")
-    return pack(REPO_ROOT)
+    return _pack(REPO_ROOT)
+
+
+def _pack(root: Path | str = "./", platform: str | None = None) -> Path:
+    """Pack a local charm and return it."""
+    cmd = ["charmcraft", "pack", "--project-dir", root]
+    if platform:
+        cmd.extend(["--platform", platform])
+    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    # stderr looks like:
+    # > charmcraft pack
+    # Packed tempo-coordinator-k8s_ubuntu@24.04-amd64.charm
+    # Packed tempo-coordinator-k8s_ubuntu@22.04-amd64.charm
+    packed_charms = [
+        line.split()[1]
+        for line in proc.stderr.strip().splitlines()
+        if line.startswith("Packed")
+    ]
+    if not packed_charms:
+        raise ValueError(
+            "Unable to get packed charm(s)!"
+            f" ({cmd!r} completed with {proc.returncode=}, {proc.stdout=}, {proc.stderr=})"
+        )
+    if len(packed_charms) > 1:
+        raise ValueError(
+            "This charm supports multiple platforms. "
+            "Pass a `platform` argument to control which charm you're getting instead."
+        )
+    return Path(packed_charms[0]).resolve()

--- a/tests/integration/test_colocated_profilers.py
+++ b/tests/integration/test_colocated_profilers.py
@@ -8,13 +8,13 @@ PYRO_TESTER_APP_NAME = "pyroscope-tester"
 UNINVITED_GUEST = APP_NAME + "guest"
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 def test_deploy(juju: Juju, charm):
     juju.deploy(charm, APP_NAME, constraints={"virt-type": "virtual-machine"})
     juju.wait(jubilant.all_active, timeout=5 * 60, error=jubilant.any_error, delay=10, successes=3)
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 def test_deploy_second_profiler_same_machine(juju: Juju, charm):
     machine_id = list(juju.status().apps[APP_NAME].units.values())[0].machine
     juju.deploy(charm, UNINVITED_GUEST, to=machine_id)
@@ -33,6 +33,6 @@ def test_blocked_status(juju: Juju):
     assert "is already being profiled" in app_status.message
 
 
-@pytest.mark.teardown
+@pytest.mark.juju_teardown
 def test_cleanup(juju):
     juju.remove_application(UNINVITED_GUEST, force=True)

--- a/tests/integration/test_profiling_integration.py
+++ b/tests/integration/test_profiling_integration.py
@@ -17,7 +17,7 @@ from pytest_bdd import given, when, then
 pytestmark = pytest.mark.usefixtures("patch_update_status_interval")
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @given("an ebpf profiler charm is deployed on a juju virtual machine")
 def test_deploy(juju: Juju, charm):
     juju.deploy(charm, APP_NAME, constraints={"virt-type": "virtual-machine"})
@@ -34,7 +34,7 @@ def test_profiler_running(juju: Juju):
     assert out
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @given("an otel collector charm is deployed on the same machine")
 def test_deploy_otel_collector(juju: Juju):
     juju.deploy(

--- a/tests/integration/test_profiling_integration_tls.py
+++ b/tests/integration/test_profiling_integration_tls.py
@@ -18,7 +18,7 @@ SSC_APP_NAME = "ssc"
 pytestmark = pytest.mark.usefixtures("patch_update_status_interval")
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @given("an ebpf profiler charm is deployed on a juju virtual machine")
 def test_deploy(juju: Juju, charm):
     juju.deploy(charm, APP_NAME, constraints={"virt-type": "virtual-machine"})
@@ -34,7 +34,7 @@ def test_profiler_running(juju: Juju):
     assert out
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @given("an otel collector charm is deployed on the same machine")
 def test_deploy_otel_collector(juju: Juju):
     juju.deploy(
@@ -52,7 +52,7 @@ def test_deploy_otel_collector(juju: Juju):
     )
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @given("a certificates provider charm is deployed")
 def test_deploy_ssc(juju: Juju):
     juju.deploy("self-signed-certificates", SSC_APP_NAME)
@@ -62,7 +62,7 @@ def test_deploy_ssc(juju: Juju):
     )
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @given("the certificates provider charm is integrated with the collector to enable TLS")
 def test_integrate_ssc_collector(juju: Juju):
     juju.integrate(f"{OTEL_COLLECTOR_APP_NAME}:receive-server-cert", SSC_APP_NAME)
@@ -80,7 +80,7 @@ def test_integrate_ssc_collector(juju: Juju):
     )
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @given("the certificates provider charm is integrated with the profiler to provide the CA")
 def test_integrate_ssc_profiler(juju: Juju):
     juju.integrate(f"{APP_NAME}:receive-ca-cert", SSC_APP_NAME)

--- a/tests/integration/test_self_monitoring.py
+++ b/tests/integration/test_self_monitoring.py
@@ -33,7 +33,7 @@ def _trigger_update_status_event(juju: Juju, unit_name: str):
     )
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @given("an otel-ebpf-profiler charm is deployed")
 def test_deploy_profiler(juju: Juju, charm):
     juju.deploy(charm, APP_NAME, constraints={"virt-type": "virtual-machine"})
@@ -46,7 +46,7 @@ def test_deploy_profiler(juju: Juju, charm):
     )
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @when("an opentelemetry-collector charm is deployed")
 def test_deploy_otel_collector(juju: Juju):
     # TODO: https://github.com/canonical/opentelemetry-collector-operator/issues/85
@@ -57,7 +57,7 @@ def test_deploy_otel_collector(juju: Juju):
     juju.deploy(OTEL_COLLECTOR_APP_NAME, channel=COS_CHANNEL, base=APP_BASE, config=config)
 
 
-@pytest.mark.setup
+@pytest.mark.juju_setup
 @when("integrated with the otel-ebpf-profiler over cos-agent")
 def test_integrate_cos_agent(juju: Juju):
     juju.integrate(

--- a/tests/terraform/main.tf
+++ b/tests/terraform/main.tf
@@ -1,5 +1,5 @@
 module "otel-ebpf-profiler" {
-  source  = "../../terraform"
-  model   = var.model
-  channel = var.channel
+  source     = "../../terraform"
+  model_uuid = var.model_uuid
+  channel    = var.channel
 }

--- a/tests/terraform/test_terraform_module.py
+++ b/tests/terraform/test_terraform_module.py
@@ -1,3 +1,4 @@
+import json
 import shlex
 import subprocess
 from pathlib import Path
@@ -21,11 +22,15 @@ def juju():
 @given("a machine model")
 @when("you run terraform apply using the provided module")
 def test_terraform_apply(juju):
+    model_output = juju.cli(
+        "show-model", "--format", "json", juju.model, include_model=False
+    )
+    model_uuid = json.loads(model_output)[juju.model]["model-uuid"]
     subprocess.run(shlex.split(f"terraform -chdir={THIS_DIRECTORY} init"), check=True)
     subprocess.run(
         shlex.split(
             f'terraform -chdir={THIS_DIRECTORY} apply -var="channel={CHARM_CHANNEL}" '
-            f'-var="model={juju.model}" -auto-approve'
+            f'-var="model_uuid={model_uuid}" -auto-approve'
         ),
         check=True,
     )

--- a/tests/terraform/variables.tf
+++ b/tests/terraform/variables.tf
@@ -1,5 +1,5 @@
-variable "model" {
-  description = "Model name to deploy the charm to"
+variable "model_uuid" {
+  description = "Reference to an existing model resource or data source for the model to deploy to"
   type        = string
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -275,7 +275,7 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-bdd", marker = "extra == 'dev'" },
-    { name = "pytest-jubilant", marker = "extra == 'dev'" },
+    { name = "pytest-jubilant", marker = "extra == 'dev'", specifier = ">=2,<3" },
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "tenacity", marker = "extra == 'dev'" },
@@ -421,15 +421,15 @@ wheels = [
 
 [[package]]
 name = "pytest-jubilant"
-version = "1.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jubilant" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/01/a089e0b323d87519e19425809062090a615cc10fdf8879ecf0ec5c5dfc36/pytest_jubilant-1.1.tar.gz", hash = "sha256:755dd5a1b4c295773a01ed3005cec1bd106a46bf51ec041ae56004dd558e8f9c", size = 12368, upload-time = "2025-07-28T06:42:44.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/b6/d98999f1d0a0c9313154fe7bf8f4e3639729b7052c736f2f12cd7025201c/pytest_jubilant-2.0.0.tar.gz", hash = "sha256:c5f8382ac0b43bca8ef87e309f587e2fc1751ff7b2677dd28a66989b6605e063", size = 16250, upload-time = "2026-03-29T23:39:57.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/e2/0d9124119c994aba4fbb48457a3dde01d5af5db1cd095be7b03bc6b21215/pytest_jubilant-1.1-py3-none-any.whl", hash = "sha256:1c643b0e64173e405988074e551dd2101805412d807c3c0e51983b52f8b198d4", size = 12040, upload-time = "2025-07-28T06:42:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c3/234c3ec22b230e7e33732f91d19d72ad84101a97353b03be3450e4188c5c/pytest_jubilant-2.0.0-py3-none-any.whl", hash = "sha256:28fcf3750100eda16658c2967af099a39199af9fd102ab3b5ba230a028efec3e", size = 13354, upload-time = "2026-03-29T23:39:56.66Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

The `pytest-jubilant` [2.0 release](https://github.com/canonical/pytest-jubilant/releases/tag/v2.0.0) breaks this repo's tests.

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR migrates the tests to use the 2.0 API. This includes defining a copy of the `pack` helper dropped from `pytest-jubilant`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Charm Tech will maintain the `pytest-jubilant` 2.0 API going forward. We dropped `pack` to scope the library more tightly to `pytest` + `jubilant`. In general, we think it's cleaner to avoid calling `charmcraft pack` inside your Python integration test suite.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Integration tests should pass.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A.