### PR TITLE
feat(terraform): add channel validation and split outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ version
 *.hcl
 .terraform
 *.tfstate*
+# Terraform
+**/.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -55,13 +55,13 @@ For example, if you want to deploy `otel-ebpf-profiler` to a machine with a diff
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.15.0 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 0.15.0 |
+| <a name="provider_juju"></a> [juju](#provider\_juju) | ~> 1.0 |
 
 ## Modules
 
@@ -75,7 +75,7 @@ No modules.
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
 | <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
 | <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64 virt-type=virtual-machine"` | no |
-| <a name="input_model"></a> [model](#input\_model) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
 | <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
 | <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
 | <a name="input_trust"></a> [trust](#input\_trust) | Whether this application is trusted to control the cluster | `bool` | `false` | no |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -48,3 +48,44 @@ The `virt-type` constraint should not be changed or removed, as deploying this c
 
 For example, if you want to deploy `otel-ebpf-profiler` to a machine with a different architecture, you should set `constraints` to `arch=arm64,virt-type=virtual-machine`.
 
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 0.15.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_juju"></a> [juju](#provider\_juju) | >= 0.15.0 |
+
+## Modules
+
+No modules.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Name to give the deployed application | `string` | `"otel-ebpf-profiler"` | no |
+| <a name="input_channel"></a> [channel](#input\_channel) | Channel that the charm is deployed from | `string` | n/a | yes |
+| <a name="input_config"></a> [config](#input\_config) | Map of the charm configuration options | `map(string)` | `{}` | no |
+| <a name="input_constraints"></a> [constraints](#input\_constraints) | String listing constraints for this application | `string` | `"arch=amd64 virt-type=virtual-machine"` | no |
+| <a name="input_model"></a> [model](#input\_model) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | Revision number of the charm | `number` | `null` | no |
+| <a name="input_storage_directives"></a> [storage\_directives](#input\_storage\_directives) | Map of storage used by the application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_trust"></a> [trust](#input\_trust) | Whether this application is trusted to control the cluster | `bool` | `false` | no |
+| <a name="input_units"></a> [units](#input\_units) | Unit count/scale | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
+<!-- END_TF_DOCS -->

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@ resource "juju_application" "otel_ebpf_profiler" {
   name               = var.app_name
   config             = var.config
   constraints        = var.constraints
-  model              = var.model
+  model_uuid         = var.model_uuid
   storage_directives = var.storage_directives
   trust              = var.trust
   units              = var.units

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,13 +2,15 @@ output "app_name" {
   value = juju_application.otel_ebpf_profiler.name
 }
 
-output "endpoints" {
+output "provides" {
   value = {
-    # Requires
+    cos-agent = "cos-agent",
+  }
+}
+
+output "requires" {
+  value = {
     profiling       = "profiling",
     receive_ca_cert = "receive-ca-cert",
-
-    # Provides
-    cos-agent = "cos-agent",
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,7 +27,7 @@ variable "constraints" {
   default = "arch=amd64 virt-type=virtual-machine"
 }
 
-variable "model" {
+variable "model_uuid" {
   description = "Reference to an existing model resource or data source for the model to deploy to"
   type        = string
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.15.0"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

Split the  output into separate  and  outputs.

See canonical/alertmanager-k8s-operator#403 and canonical/alertmanager-k8s-operator#396 for reference.