### PR TITLE
chore(ci): bump reusable workflows to v2

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@v2
     with:
       promotion: ${{ github.event.inputs.promotion }}
     secrets: inherit

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,14 +9,14 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
     secrets: inherit
     with:
       provider: machine
 
   terraform-deploy-tests:
     name: Run terraform deployment tests
-    uses: canonical/observability/.github/workflows/run-tox-environment.yaml@v1
+    uses: canonical/observability/.github/workflows/run-tox-environment.yaml@v2
     with:
       tox-env-name: terraform
       run-on: "self-hosted-linux-amd64-noble-medium"

--- a/.github/workflows/quality-gates.yaml
+++ b/.github/workflows/quality-gates.yaml
@@ -12,5 +12,5 @@ on:
 jobs:
   quality-gates:
     name: Run quality gates
-    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    uses: canonical/observability/.github/workflows/charm-release.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v2
     secrets: inherit
     with:
       provider: machine

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -8,5 +8,5 @@ on:
 jobs:
     tics:
         name: TiCs
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v1
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v2
         secrets: inherit

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,6 +9,6 @@ on:
 jobs:
   update-lib:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
     secrets: inherit
 

--- a/tests/terraform/main.tf
+++ b/tests/terraform/main.tf
@@ -1,5 +1,5 @@
 module "otel-ebpf-profiler" {
-  source  = "../../terraform"
-  model   = var.model
-  channel = var.channel
+  source     = "../../terraform"
+  model_uuid = var.model_uuid
+  channel    = var.channel
 }

--- a/tests/terraform/test_terraform_module.py
+++ b/tests/terraform/test_terraform_module.py
@@ -1,3 +1,4 @@
+import json
 import shlex
 import subprocess
 from pathlib import Path
@@ -21,11 +22,15 @@ def juju():
 @given("a machine model")
 @when("you run terraform apply using the provided module")
 def test_terraform_apply(juju):
+    model_output = juju.cli(
+        "show-model", "--format", "json", juju.model, include_model=False
+    )
+    model_uuid = json.loads(model_output)[juju.model]["model-uuid"]
     subprocess.run(shlex.split(f"terraform -chdir={THIS_DIRECTORY} init"), check=True)
     subprocess.run(
         shlex.split(
             f'terraform -chdir={THIS_DIRECTORY} apply -var="channel={CHARM_CHANNEL}" '
-            f'-var="model={juju.model}" -auto-approve'
+            f'-var="model_uuid={model_uuid}" -auto-approve'
         ),
         check=True,
     )

--- a/tests/terraform/variables.tf
+++ b/tests/terraform/variables.tf
@@ -1,5 +1,5 @@
-variable "model" {
-  description = "Model name to deploy the charm to"
+variable "model_uuid" {
+  description = "Reference to an existing model resource or data source for the model to deploy to"
   type        = string
 }
 


### PR DESCRIPTION
Update all `canonical/observability` reusable workflow references to use the `v2` tag.

Drive-by: fix Terraform test.